### PR TITLE
rest, httpinterface: include unless they're nil

### DIFF
--- a/templates/default/etc/mongodb.conf.erb
+++ b/templates/default/etc/mongodb.conf.erb
@@ -83,7 +83,9 @@ unixSocketPrefix = <%= @socket %>
 smallfiles = <%= @smallfiles %>
 
 # REST interface
-rest = <%= @rest %>
+<% unless @rest.nil? %>rest = <%= @rest %>
+<% else %># rest not defined<% end %>
 
 # HTTP interface
-httpinterface = <%= @httpinterface %>
+<% unless @httpinterface.nil? %>httpinterface = <%= @httpinterface %>
+<% else %># httpinterface not defined<% end %>


### PR DESCRIPTION
These two options are not understood by mongodb 3.6. Including these in the configuration files makes this cookbook incompatible with this version. This change allows this cookbook to be used with mongodb 3.6 and also allows the use of the "rest" and "httpinterface" options with older versions.